### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,8 @@
     }
   ],
   "require": {
-    "guzzlehttp/guzzle": "6.0.1",
-    "phpunit/phpunit": "4.8.x-dev"
+    "guzzlehttp/guzzle": "6.1.*",
+    "phpunit/phpunit": "5.2.*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Installing telstraSMS as a dependancy on up-to-date projects causes versioning issues because the dependencies listed in composer.json are out of date.
